### PR TITLE
fix: CJK約物隣接の bold/em が壊れる問題を修正

### DIFF
--- a/lib/renderer/md.js
+++ b/lib/renderer/md.js
@@ -6,16 +6,17 @@ import code from './md/code.js';
 // CJK約物（）など）の直後にある closing ** が認識されない CommonMark 由来の問題を修正する。
 // emStrongRDelimAst の group1 lookahead に \p{L} を追加し、
 // 約物 + ** + 文字（CJK含む）の並びも closing delimiter と見なすようにする。
+let _cjkFixed = false;
 marked.use({
   tokenizer: {
     emStrong(src, maskedSrc, prevChar = '') {
-      if (!this._cjkFixed) {
+      if (!_cjkFixed) {
         const orig = this.rules.inline.emStrongRDelimAst;
         this.rules.inline.emStrongRDelimAst = new RegExp(
           orig.source.replace('(?=[\\s]|$)', '(?=[\\s\\p{L}]|$)'),
           orig.flags
         );
-        this._cjkFixed = true;
+        _cjkFixed = true;
       }
       return false;
     }

--- a/lib/renderer/md.js
+++ b/lib/renderer/md.js
@@ -3,6 +3,25 @@ import { marked } from 'marked';
 // なんか増えたらココに追記
 import code from './md/code.js';
 
+// CJK約物（）など）の直後にある closing ** が認識されない CommonMark 由来の問題を修正する。
+// emStrongRDelimAst の group1 lookahead に \p{L} を追加し、
+// 約物 + ** + 文字（CJK含む）の並びも closing delimiter と見なすようにする。
+marked.use({
+  tokenizer: {
+    emStrong(src, maskedSrc, prevChar = '') {
+      if (!this._cjkFixed) {
+        const orig = this.rules.inline.emStrongRDelimAst;
+        this.rules.inline.emStrongRDelimAst = new RegExp(
+          orig.source.replace('(?=[\\s]|$)', '(?=[\\s\\p{L}]|$)'),
+          orig.flags
+        );
+        this._cjkFixed = true;
+      }
+      return false;
+    }
+  }
+});
+
 const renderFunc = {
   code,
 };

--- a/test/cgmd/renderer/md.js
+++ b/test/cgmd/renderer/md.js
@@ -22,6 +22,14 @@ describe('#renderToken', function() {
   });
 });
 
+describe('#render (CJK punctuation)', function() {
+  it('CJK約物の直後の closing ** が正しく認識されること', function() {
+    const res = renderer.render('**foo（bar）**baz**qux**');
+    assert(res.includes('<strong>foo（bar）</strong>'), 'CJK約物で閉じるboldが壊れている');
+    assert(res.includes('<strong>qux</strong>'), '2つ目のboldが壊れている');
+  });
+});
+
 describe('#render', function() {
   it('markedと同じ内容でふつうのMarkdownをレンダリングできること', function() {
     const res1    = renderer.render('- foo\n- bar');


### PR DESCRIPTION
## Summary

- `**太字（strong）**にして` のように CJK 閉じ括弧の直後に `**` があり、その後に通常テキストが続くと bold が正しくレンダリングされない問題を修正
- CommonMark 由来の制限（closing delimiter の right-flanking 判定）が原因で、marked はこれを仕様通りに実装しているため marked 側では修正されない
- `marked.use()` で `emStrong` をオーバーライドし、`emStrongRDelimAst` の lookahead に `\p{L}` を追加することで CJK 文字の前でも closing delimiter と認識されるよう対処

## Test plan

- [ ] `npm test` が全テスト通過することを確認
- [ ] `**foo（bar）**baz**qux**` → `<strong>foo（bar）</strong>baz<strong>qux</strong>` となることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)